### PR TITLE
feat: Update to odbc-api 24.1.2.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,9 +1122,9 @@ dependencies = [
 
 [[package]]
 name = "odbc-api"
-version = "23.0.1"
+version = "24.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d280b37351245342f322837062eede4501a18c3dc999a77aa990be31ef79812"
+checksum = "b68ad0db51ec156636e93ff7075d848b5fcc09f04ad7dd69ddb02b6bf145216c"
 dependencies = [
  "atoi",
  "log",
@@ -1136,9 +1136,9 @@ dependencies = [
 
 [[package]]
 name = "odbc-sys"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9f3ae4f9a232be79c302213d765e7c00936484fb1375f7edfcfa52fe446f14"
+checksum = "245cb4fe8236df4fd352ba96075d754233c6509d654d9f1c1482158b7d6c083d"
 
 [[package]]
 name = "once_cell"


### PR DESCRIPTION
This implies a behaviour change which avoids explicitly closing cursors
during tear down, but rather leaves it to the driver to do so than
freeing the statement handle.
