### PR TITLE
execute

### DIFF
--- a/python/arrow_odbc-stubs/arrow_odbc/__init__.pyi
+++ b/python/arrow_odbc-stubs/arrow_odbc/__init__.pyi
@@ -49,8 +49,8 @@ class _Lib:
     def arrow_odbc_reader_free(self, reader: FFI.CData) -> None: ...
     def arrow_odbc_connection_execute(
         self,
-        reader: FFI.CData,
         connection: FFI.CData,
+        reader: FFI.CData,
         query_buf: bytes,
         query_len: int,
         parameters: FFI.CData,

--- a/python/arrow_odbc-stubs/arrow_odbc/__init__.pyi
+++ b/python/arrow_odbc-stubs/arrow_odbc/__init__.pyi
@@ -47,7 +47,7 @@ class _Lib:
     # --- reader.rs ---
     def arrow_odbc_reader_make(self, reader_out: FFI.CData) -> None: ...
     def arrow_odbc_reader_free(self, reader: FFI.CData) -> None: ...
-    def arrow_odbc_reader_query(
+    def arrow_odbc_connection_execute(
         self,
         reader: FFI.CData,
         connection: FFI.CData,

--- a/python/arrow_odbc/connect.py
+++ b/python/arrow_odbc/connect.py
@@ -366,8 +366,8 @@ class Connection:
             benefits, after you have verified that your system locale is set to UTF-8.
         """
         # First iteration: allocate a throwaway reader so we can reuse the existing
-        # ``arrow_odbc_reader_query`` FFI entry point. The reader is freed when ``reader`` goes out
-        # of scope, which also drops any cursor the statement may have produced.
+        # ``arrow_odbc_connection_execute`` FFI entry point. The reader is freed when ``reader``
+        # goes out of scope, which also drops any cursor the statement may have produced.
         reader = BatchReaderRaii()
         self._query(
             reader=reader,
@@ -444,7 +444,7 @@ class Connection:
             query_timeout_sec_pointer = ffi.new("uintptr_t *")
             query_timeout_sec_pointer[0] = query_timeout_sec
 
-        error = lib.arrow_odbc_reader_query(
+        error = lib.arrow_odbc_connection_execute(
             reader.handle,
             self.handle,
             query_bytes,

--- a/python/arrow_odbc/connect.py
+++ b/python/arrow_odbc/connect.py
@@ -185,7 +185,7 @@ class Connection:
         """
         reader = BatchReaderRaii()
 
-        self._query(
+        self._execute(
             reader=reader,
             query=query,
             parameters=parameters,
@@ -365,7 +365,7 @@ class Connection:
             systems you may want to set this to ``TextEncoding::Utf8`` to gain performance
             benefits, after you have verified that your system locale is set to UTF-8.
         """
-        self._query(
+        self._execute(
             reader=None,
             query=query,
             parameters=parameters,
@@ -397,14 +397,14 @@ class Connection:
         error = lib.arrow_odbc_connection_set_autocommit(self.handle, autocommit)
         raise_on_error(error)
 
-    def _query(
+    def _execute(
         self,
         reader: BatchReaderRaii | None,
         query: str,
         parameters: Sequence[str | None] | None,
         text_encoding: TextEncoding,
         query_timeout_sec: int | None,
-    ) -> None:
+    ):
         query_bytes = query.encode("utf-8")
 
         if parameters is None:

--- a/python/arrow_odbc/connect.py
+++ b/python/arrow_odbc/connect.py
@@ -445,8 +445,8 @@ class Connection:
             query_timeout_sec_pointer[0] = query_timeout_sec
 
         error = lib.arrow_odbc_connection_execute(
-            reader.handle,
             self.handle,
+            reader.handle,
             query_bytes,
             len(query_bytes),
             parameters_array,

--- a/python/arrow_odbc/connect.py
+++ b/python/arrow_odbc/connect.py
@@ -365,12 +365,8 @@ class Connection:
             systems you may want to set this to ``TextEncoding::Utf8`` to gain performance
             benefits, after you have verified that your system locale is set to UTF-8.
         """
-        # First iteration: allocate a throwaway reader so we can reuse the existing
-        # ``arrow_odbc_connection_execute`` FFI entry point. The reader is freed when ``reader``
-        # goes out of scope, which also drops any cursor the statement may have produced.
-        reader = BatchReaderRaii()
         self._query(
-            reader=reader,
+            reader=None,
             query=query,
             parameters=parameters,
             text_encoding=payload_text_encoding,
@@ -403,7 +399,7 @@ class Connection:
 
     def _query(
         self,
-        reader: BatchReaderRaii,
+        reader: BatchReaderRaii | None,
         query: str,
         parameters: Sequence[str | None] | None,
         text_encoding: TextEncoding,
@@ -444,9 +440,10 @@ class Connection:
             query_timeout_sec_pointer = ffi.new("uintptr_t *")
             query_timeout_sec_pointer[0] = query_timeout_sec
 
+        reader_handle = ffi.NULL if reader is None else reader.handle
         error = lib.arrow_odbc_connection_execute(
             self.handle,
-            reader.handle,
+            reader_handle,
             query_bytes,
             len(query_bytes),
             parameters_array,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -176,14 +176,14 @@ pub unsafe extern "C" fn arrow_odbc_connection_rollback(
 
 /// Creates an Arrow ODBC reader instance.
 ///
-/// Executes the SQL Query and moves the reader into cursor state.
+/// Executes the SQL Query and optionally moves the reader into cursor state.
 ///
 /// # Safety
 ///
 /// * `connection` must point to a valid OdbcConnection. This function takes ownership of the
 ///   connection, even in case of an error. So The connection must not be freed explicitly
 ///   afterwards.
-/// * `reader` must point to a valid reader in empty state.
+/// * `reader` must either be NULL or point to a valid reader.
 /// * `query_buf` must point to a valid utf-8 string
 /// * `query_len` describes the len of `query_buf` in bytes.
 /// * `parameters` must contain only valid pointers. This function takes ownership of all of them
@@ -205,7 +205,7 @@ pub unsafe extern "C" fn arrow_odbc_connection_rollback(
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn arrow_odbc_connection_execute(
     connection: NonNull<ArrowOdbcConnection>,
-    mut reader: NonNull<ArrowOdbcReader>,
+    reader: *mut ArrowOdbcReader,
     query_buf: *const u8,
     query_len: usize,
     parameters: *const *mut ArrowOdbcParameter,
@@ -232,12 +232,15 @@ pub unsafe extern "C" fn arrow_odbc_connection_execute(
         Some(unsafe { *query_timeout_sec })
     };
 
-    try_!(unsafe { reader.as_mut() }.promote_to_cursor(
-        connection,
-        query,
-        &parameters[..],
-        query_timeout_sec
-    ));
+    let mut local_reader;
+    let reader = if reader.is_null() {
+        local_reader = ArrowOdbcReader::empty();
+        &mut local_reader
+    } else {
+        unsafe { &mut *reader }
+    };
+
+    try_!(reader.promote_to_cursor(connection, query, &parameters[..], query_timeout_sec));
 
     null_mut() // Ok(())
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -10,7 +10,7 @@ use arrow_odbc::odbc_api::{
 };
 use log::debug;
 
-use crate::{ArrowOdbcError, try_};
+use crate::{ArrowOdbcError, ArrowOdbcReader, parameter::ArrowOdbcParameter, try_};
 
 /// Opaque type to transport connection to an ODBC Datasource over language boundry
 pub struct ArrowOdbcConnection(SharedConnection<'static>);
@@ -172,4 +172,72 @@ pub unsafe extern "C" fn arrow_odbc_connection_rollback(
     let connection = unsafe { connection.as_ref() };
     try_!(connection.rollback());
     null_mut()
+}
+
+/// Creates an Arrow ODBC reader instance.
+///
+/// Executes the SQL Query and moves the reader into cursor state.
+///
+/// # Safety
+///
+/// * `reader` must point to a valid reader in empty state.
+/// * `connection` must point to a valid OdbcConnection. This function takes ownership of the
+///   connection, even in case of an error. So The connection must not be freed explicitly
+///   afterwards.
+/// * `query_buf` must point to a valid utf-8 string
+/// * `query_len` describes the len of `query_buf` in bytes.
+/// * `parameters` must contain only valid pointers. This function takes ownership of all of them
+///   independent if the function succeeds or not. Yet it does not take ownership of the array
+///   itself.
+/// * `parameters_len` number of elements in parameters.
+/// * `max_text_size` optional upper bound for the size of text columns. Use `0` to indicate that no
+///   uppper bound applies.
+/// * `max_binary_size` optional upper bound for the size of binary columns. Use `0` to indicate
+///   that no uppper bound applies.
+/// * `fallibale_allocations`: `TRUE` if allocations should return an error, `FALSE` if it is fine
+///   to abort the process. Enabling might have a performance overhead, so it might be desirable to
+///   disable it, if you know there is enough memory available.
+/// * `schema`: Optional input arrow schema. NULL means no input schema is supplied. Should a
+///   schema be supplied `schema` Rust will take ownership of it an the `schema` will be
+///   overwritten with an empty one. This means the Python code, must only deallocate the memory
+///   directly pointed to by `schema`, but not freeing the resources of the passed schema.
+/// * `query_timout_sec`: Optional query timeout in seconds. If `NULL` no timeout is applied.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn arrow_odbc_reader_query(
+    mut reader: NonNull<ArrowOdbcReader>,
+    connection: NonNull<ArrowOdbcConnection>,
+    query_buf: *const u8,
+    query_len: usize,
+    parameters: *const *mut ArrowOdbcParameter,
+    parameters_len: usize,
+    query_timeout_sec: *const usize,
+) -> *mut ArrowOdbcError {
+    let connection = unsafe { connection.as_ref() }.inner();
+    // Transtlate C Args into more idiomatic rust representations
+    let query = unsafe { slice::from_raw_parts(query_buf, query_len) };
+    let query = str::from_utf8(query).unwrap();
+
+    let parameters = if parameters.is_null() {
+        Vec::new()
+    } else {
+        unsafe { slice::from_raw_parts(parameters, parameters_len) }
+            .iter()
+            .map(|&p| unsafe { Box::from_raw(p) }.unwrap())
+            .collect()
+    };
+
+    let query_timeout_sec = if query_timeout_sec.is_null() {
+        None
+    } else {
+        Some(unsafe { *query_timeout_sec })
+    };
+
+    try_!(unsafe { reader.as_mut() }.promote_to_cursor(
+        connection,
+        query,
+        &parameters[..],
+        query_timeout_sec
+    ));
+
+    null_mut() // Ok(())
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -203,7 +203,7 @@ pub unsafe extern "C" fn arrow_odbc_connection_rollback(
 ///   directly pointed to by `schema`, but not freeing the resources of the passed schema.
 /// * `query_timout_sec`: Optional query timeout in seconds. If `NULL` no timeout is applied.
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn arrow_odbc_reader_query(
+pub unsafe extern "C" fn arrow_odbc_connection_execute(
     mut reader: NonNull<ArrowOdbcReader>,
     connection: NonNull<ArrowOdbcConnection>,
     query_buf: *const u8,

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -180,10 +180,10 @@ pub unsafe extern "C" fn arrow_odbc_connection_rollback(
 ///
 /// # Safety
 ///
-/// * `reader` must point to a valid reader in empty state.
 /// * `connection` must point to a valid OdbcConnection. This function takes ownership of the
 ///   connection, even in case of an error. So The connection must not be freed explicitly
 ///   afterwards.
+/// * `reader` must point to a valid reader in empty state.
 /// * `query_buf` must point to a valid utf-8 string
 /// * `query_len` describes the len of `query_buf` in bytes.
 /// * `parameters` must contain only valid pointers. This function takes ownership of all of them
@@ -204,8 +204,8 @@ pub unsafe extern "C" fn arrow_odbc_connection_rollback(
 /// * `query_timout_sec`: Optional query timeout in seconds. If `NULL` no timeout is applied.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn arrow_odbc_connection_execute(
-    mut reader: NonNull<ArrowOdbcReader>,
     connection: NonNull<ArrowOdbcConnection>,
+    mut reader: NonNull<ArrowOdbcReader>,
     query_buf: *const u8,
     query_len: usize,
     parameters: *const *mut ArrowOdbcParameter,

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -5,84 +5,15 @@ use std::{
     mem::swap,
     os::raw::c_int,
     ptr::{NonNull, null_mut},
-    slice, str,
     sync::Arc,
 };
 
 use arrow::ffi::{FFI_ArrowArray, FFI_ArrowSchema};
 use arrow_odbc::{OdbcReaderBuilder, TextEncoding};
 
-use crate::{ArrowOdbcConnection, ArrowOdbcError, parameter::ArrowOdbcParameter, try_};
+use crate::{ArrowOdbcError, try_};
 
 pub use self::arrow_odbc_reader::ArrowOdbcReader;
-
-/// Creates an Arrow ODBC reader instance.
-///
-/// Executes the SQL Query and moves the reader into cursor state.
-///
-/// # Safety
-///
-/// * `reader` must point to a valid reader in empty state.
-/// * `connection` must point to a valid OdbcConnection. This function takes ownership of the
-///   connection, even in case of an error. So The connection must not be freed explicitly
-///   afterwards.
-/// * `query_buf` must point to a valid utf-8 string
-/// * `query_len` describes the len of `query_buf` in bytes.
-/// * `parameters` must contain only valid pointers. This function takes ownership of all of them
-///   independent if the function succeeds or not. Yet it does not take ownership of the array
-///   itself.
-/// * `parameters_len` number of elements in parameters.
-/// * `max_text_size` optional upper bound for the size of text columns. Use `0` to indicate that no
-///   uppper bound applies.
-/// * `max_binary_size` optional upper bound for the size of binary columns. Use `0` to indicate
-///   that no uppper bound applies.
-/// * `fallibale_allocations`: `TRUE` if allocations should return an error, `FALSE` if it is fine
-///   to abort the process. Enabling might have a performance overhead, so it might be desirable to
-///   disable it, if you know there is enough memory available.
-/// * `schema`: Optional input arrow schema. NULL means no input schema is supplied. Should a
-///   schema be supplied `schema` Rust will take ownership of it an the `schema` will be
-///   overwritten with an empty one. This means the Python code, must only deallocate the memory
-///   directly pointed to by `schema`, but not freeing the resources of the passed schema.
-/// * `query_timout_sec`: Optional query timeout in seconds. If `NULL` no timeout is applied.
-#[unsafe(no_mangle)]
-pub unsafe extern "C" fn arrow_odbc_reader_query(
-    mut reader: NonNull<ArrowOdbcReader>,
-    connection: NonNull<ArrowOdbcConnection>,
-    query_buf: *const u8,
-    query_len: usize,
-    parameters: *const *mut ArrowOdbcParameter,
-    parameters_len: usize,
-    query_timeout_sec: *const usize,
-) -> *mut ArrowOdbcError {
-    let connection = unsafe { connection.as_ref() }.inner();
-    // Transtlate C Args into more idiomatic rust representations
-    let query = unsafe { slice::from_raw_parts(query_buf, query_len) };
-    let query = str::from_utf8(query).unwrap();
-
-    let parameters = if parameters.is_null() {
-        Vec::new()
-    } else {
-        unsafe { slice::from_raw_parts(parameters, parameters_len) }
-            .iter()
-            .map(|&p| unsafe { Box::from_raw(p) }.unwrap())
-            .collect()
-    };
-
-    let query_timeout_sec = if query_timeout_sec.is_null() {
-        None
-    } else {
-        Some(unsafe { *query_timeout_sec })
-    };
-
-    try_!(unsafe { reader.as_mut() }.promote_to_cursor(
-        connection,
-        query,
-        &parameters[..],
-        query_timeout_sec
-    ));
-
-    null_mut() // Ok(())
-}
 
 /// Creates an empty Arrow ODBC reader instance. Useful for passing ownership of the reader in
 /// Python code. The previous owner can use this to express the move by holding an empty instance.


### PR DESCRIPTION
- **chore: upgrade Python dependencies**
- **dev: Improve linting**
- **feat: Add Connection.execute**
- **refactor: Move arrow_odbc_reader_query to connection.rs**
- **refactor: Rename arrow_odbc_reader_query to arrow_odbc_connection_execute**
- **refactor: Make connection the first parameter of arrow_odbc_connection_execute**
- **refactor: reader is now optional in arrow_odbc_connection_execute.**
- **refactor: Rename _query to _execute**
