### PR TITLE
perf: Update to upstream arrow-odbc Rust crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-odbc"
-version = "25.1.0"
+version = "25.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d474e2d8c72339f342a7a2fcdca8f006957d6afa63a5adba329c9ddd28165075"
+checksum = "7308b7d599fc8a81f56ec409ca5d4c63b504ae18222e69e4955eab27d8ce70d2"
 dependencies = [
  "arrow",
  "atoi",
@@ -852,9 +852,9 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "ndk"


### PR DESCRIPTION
Including a change avoiding reallocating buffers when inserting text
